### PR TITLE
Adding whitelist section for NPCs we add or change. Closes #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,25 @@ code/
 .dropbox_uploader
 .bash_history
 assets/ssh/
+
+## Eulogy-quest server/quests/<zone>/<NPC>.pl whitelist
+##   All NPCs whose behavior is soon to be edited, 
+##   add them to this whitelist first!
+
+# Un-ignore the quests/ directory (but not its contents yet)
+# ((git issue #6))
+#
+## // ai-gen start (ChatGPT-4o, 0)
+!server/quests/    
+## // ai-gen end
+
+# Explicitly track only these specific files:
+#
+## // ai-gen start (ChatGPT-4o, 0)
+!server/quests/tutorialb/Vahlara.pl    
+## // ai-gen end
+#
+# (Eulogy-quest team, add your NPCs to the whitelist below)
+# (no need to copy the ai-gen part if you're instead copying me)
+# <whitelist>:
+# !server/quests/<zone>/<your_NPC>.pl


### PR DESCRIPTION
## [Overview](#overview)
The cloned .gitignore wisely does not track server/ .
If we only tracked server/quests/, we would then be tracking at least 67, 500 more files; no thanks.

Our quest-edits change NPCs whose script files live in server/quests/\<zone\>/.pl .
We must whitelist these specific files before we edit them (in a new feature branch) in order to track the NPCs original behavior.

This is the first edit of .gitignore; I will make note of the requirement inside the .gitignore .

Closes #6
(Importantly, adding the closes-magic-phrase in the title does not work. That has to be here. Furthermore, having added it to the commit message would normally send that text here to the description portion; however, we have a (terrific) template in place instead, so I don't think the commit message gets copied over, and I don't think it will close automatically without us adding thise phrase in by-hand.)

## [YouTrack Ticket](#tickets)
- https://eulogy-quest.youtrack.cloud/issue/EUL-63/First-amend-.gitignore-to-track-NPCs-we-intend-to-change

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/6