### PR TITLE
Bugfix allowing us to persist and distribute NPC changes (EUL-64/GH-8). Completion of task (EUL-62/GH-5) Demonstrate workflow proficiency.

### DIFF
--- a/server/quests/tutorialb/Vahlara.pl
+++ b/server/quests/tutorialb/Vahlara.pl
@@ -32,7 +32,7 @@ sub EVENT_SAY {
     if (quest::istaskactivityactive(3785, 1)) {
       quest::updatetaskactivity(3785, 1);
     }
-    quest::say("I'm glad you managed to escape the slave warrens in one piece.  There are many [" . quest::saylink("others") . "] who were not as lucky.  Here, take this armor we found on a kobold.  It's not much but it should keep you safe.");
+    quest::say("I'm glad you managed to escape the slave warrens in one piece.  There are many [" . quest::saylink("others") . "] who were not as lucky.  Here, take this armor we found on a kobold.  It's not much but it should keep you safe. So far our [" . quest::saylink("heroes") . "] have done well.");
     quest::popup("Equipping Armor", "<br>Vahlara has offered you a piece of kobold armor to keep you safe.<br><br>Equip the armor by dropping it onto the large rectangular icon in the center of your inventory ( <c \"#00F0F0\">i</c> ) window.  Notice that the armor automatically moves to its proper armor slot on your body.<br><br>Also note that some armor you will later obtain can only be equipped by placing it directly in its corresponding slot, e.g. dropping a breastplate onto the \"chest\" icon in your inventory. When you do this, the armor becomes \"attuned\" to your character, and you will no longer be able to trade it with other players.<br><br><c \"#F07F00\">Once you have equipped the armor, respond to Vahlara's dialogue in your Main Chat Window to continue.</c>");
   }
   if ($text=~/others/i) {
@@ -44,6 +44,9 @@ sub EVENT_SAY {
   }
   if ($text=~/bandages/i) {
     quest::say("I was a skilled tailor before I was enslaved, so I'm able to weave spiderling silk into makeshift gauzes and dressings.  But now even the spiderling silk is running scarce.  If you can bring me a piece of spiderling silk, I can give you some armor I've crafted from burlap. Burlap's no good for bandages anyway.");
+  }
+  if ($text=~/heroes/i) {
+    quest::say("Many thanks to our heroes: Kharvey, .");
   }
 }
 
@@ -57,4 +60,3 @@ sub EVENT_ITEM {
   }
   plugin::return_items(\%itemcount);
 }
-# Eulogy-quest edited file (13)


### PR DESCRIPTION

## [Overview](#overview)
Github (GH) issue 5 (youtrack card EUL-62) was an individual version of a task assigned to us all: Demonstrate proficiency in our custom client/server development environment workflow by making an otherwise simple addition to **both** the repo's README.md **and** to the script of an in-game NPC (all while doing it in a manner consistent with tracking our progress).
This second part is what necessitated the additional task of un-blocking our ability to persist and distribute these NPC changes via git version control. This was a priority workflow bugfix (EUL-64 / GH-8), as it was necessary for the rest of the team to complete their tasks.
Closes #5, Fixes #8

## [YouTrack Ticket](#tickets)
- https://eulogy-quest.youtrack.cloud/issue/EUL-64/White-listed-NPC-files-must-be-force-added-to-begin-tracking-them
- https://eulogy-quest.youtrack.cloud/issue/EUL-62/Solidify-GitHub-workflow-by-adding-name-to-Readme-editing-NPC-Ken-Harvey

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/8
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/5