### PR TITLE
[EUL-98]: Updated CODEOWNERS to be individuals instead of organization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# Github team code owners
-* @2025-S-GROUP4-EulogyQuest
+# Request review from specific users for all files
+* @kennethken73 @richvar @michaelsoffer @Kemoshu @RISINGCHART719 @hhrh @AdamoHamou @John-Zaleschuk @Kirchpa


### PR DESCRIPTION
## [Overview](#overview)
Closes #43, adds CODEOWNERS file so we can set whole team as auto-reviewers on all PRs. 

Since our team is marked as secret within the UNLV-CS472-672 organization, we must individually @ all members for PR approval. 

## [YouTrack Ticket](#tickets)
- https://eulogy-quest.youtrack.cloud/issue/EUL-98

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/43