### PR TITLE
Game-server CI/CD check via GitHub Actions

### DIFF
--- a/.github/workflows/ken/exitEq.ahk
+++ b/.github/workflows/ken/exitEq.ahk
@@ -1,0 +1,13 @@
+﻿#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+; #Warn  ; Enable warnings to assist with detecting common errors.
+; SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+SendMode, Event
+
+; Bring EverQuest to the foreground
+WinActivate, EverQuest
+WinWaitActive, EverQuest
+Sleep, 500
+
+; Send /exit to trigger logout
+Send, /exit
+Send, {Enter}

--- a/.github/workflows/ken/login.ahk
+++ b/.github/workflows/ken/login.ahk
@@ -1,0 +1,57 @@
+﻿#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+; #Warn  ; Enable warnings to assist with detecting common errors.
+; SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+SendMode, Event
+
+; === Make absolutely sure each keypress happens on the EverQuest-focuesd window
+; === Windows loves stealing focus away.
+FocusAndEnter() {
+    WinActivate, EverQuest
+    WinWaitActive, EverQuest
+    Send, {Enter}
+}
+FocusAndTab() {
+    WinActivate, EverQuest
+    WinWaitActive, EverQuest
+    Send, {Tab}
+}
+
+
+; ==== Everquest (eqemu) login automation for the Eulogy project ====
+; == Part of my CI/CD pipeline work ==
+; == Verifies whether the client can log in
+; == after any changes are made to the repo
+
+; === Config ===
+SetWorkingDir, C:\Eulogy-quest-client-local; Ensures a consistent starting directory.
+password := "buzz9099e"
+eqgameShortcut := "Eulogy-local.lnk"
+
+; Launch game client with patchme
+Run, %A_Desktop%\%eqgameShortcut%
+WinWaitActive, EverQuest
+
+Sleep, 3000      ; Wait for EULA screen
+FocusAndTab()    ; Tab away from "Decline" onto "Accept"
+
+Sleep, 1000
+FocusAndEnter()  ; Accept EULA
+
+Sleep, 1000      ; wait for SOE splash screen
+FocusAndEnter()  ; Dismiss SOE splash screen
+
+Sleep, 1000      ; wait for login intro
+FocusAndEnter()  ; Proceed past EQ intro screen
+
+Sleep, 1000      ; wait for actual login screen
+WinActivate, EverQuest
+WinWaitActive, EverQuest
+Send, %password%
+Sleep, 500
+FocusAndEnter()  ; Submit login password
+
+Sleep, 1000
+FocusAndEnter()  ; Select server
+
+Sleep, 20000     ; Long wait just in case loading takes a long time
+FocusAndEnter()  ; Log in with a character

--- a/.github/workflows/ken/start-eqemu.ps1
+++ b/.github/workflows/ken/start-eqemu.ps1
@@ -1,0 +1,150 @@
+#// ai-gen start (ChatGPT-4o, 1)
+# === Config Section ===
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$vmName = "Backup-Eulogy-quest-local-server"
+$vmIp = "192.168.56.103"          # ← Update this
+$vmUser = "sov"                  # ← Update this
+# NOTE: Don't store plain passwords; use key-based auth if possible.
+
+# === Start the VM ===
+Write-Host "Starting VM..."
+& "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe" startvm $vmName --type headless
+Start-Sleep -Seconds 10
+
+# === Wait for SSH to become available ===
+Write-Host "Waiting for SSH connectivity..."
+
+$sshReady = $false
+$maxSshWait = 90
+$sshTimer = 0
+
+while (-not $sshReady -and $sshTimer -lt $maxSshWait) {
+    try {
+        $sshTest = & ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no "$vmUser@$vmIp" "whoami"
+        Write-Host "SSH output: '$sshTest'"
+        if ($sshTest -match "$vmUser") {
+            $sshReady = $true
+            break
+        }
+    } catch {
+        Write-Host "SSH failed: $_"
+    }
+
+    Start-Sleep -Seconds 3
+    $sshTimer += 3
+    Write-Host "  ...still waiting for SSH ($sshTimer seconds)"
+}
+
+if (-not $sshReady) {
+    Write-Host "[FAIL] SSH did not become available after $maxSshWait seconds."
+    exit 1
+}
+
+Write-Host "[PASS] SSH is now available on the VM."
+
+# === Start EQEmu Server ===
+Write-Host "Starting EQEmu server inside VM..."
+$remoteCommand = @'
+cd ~/opt/akk-stack
+make up
+sleep 10
+docker-compose exec -T eqemu-server bash -c 'cd server && ./bin/spire spire:launcher start'
+'@
+
+ssh "$vmUser@$vmIp" $remoteCommand
+
+# === Wait for the world server (and zones!) to finish loading before running login.ahk
+Write-Host "Waiting for zones to come online..."
+
+$ready = $false
+$timeout = 120  # total wait time in seconds
+$waitTime = 0
+
+while (-not $ready -and $waitTime -lt $timeout) {
+    $zoneCountOutput = ssh "$vmUser@$vmIp" "ps aux | grep -v grep | grep '/home/eqemu/server/bin/zone' | wc -l"
+    $zoneCount = [int]$zoneCountOutput.Trim()
+    
+    if ($zoneCount -ge 25) {
+        $ready = $true
+        break
+    }
+
+    Start-Sleep -Seconds 3
+    $waitTime += 3
+    Write-Host "Zones online: $zoneCount (waiting for at least 25)..."
+}
+
+if ($ready) {
+    Write-Host "[PASS] Zone processes are online ($zoneCount total)."
+} else {
+    Write-Host "[FAIL] Zone processes did not reach expected count within $timeout seconds."
+    exit 1
+}
+
+# === Launch and Auto-Login EQ Client ===
+Write-Host "Launching AutoHotKey login script..."
+$ahkScript = Join-Path $scriptDir "login.ahk"
+$ahkPath = "C:\Program Files\AutoHotkey\AutoHotkeyU64.exe"
+# debug
+Write-Host "AHK Path: $ahkPath"
+Write-Host "Script Path: $ahkScript"
+# /debug
+
+# === Launch the login ahk script ===
+# But, first we log the time before the ahk script is run
+# Then we run the ahk script
+# Then we wait 70 seconds before continuing this PowerShell script
+# As the next three lines occur here nearly simultaneously
+$loginStartTime = Get-Date
+
+Start-Process $ahkPath -ArgumentList $ahkScript
+
+Start-Sleep -Seconds 70
+# This give us 70 seconds for "Start-Process $ahkPath -ArgumentList $ahkScript"
+# to run before the rest of this file executes.
+
+# === Confirm Login via Log File with Timestamp Validation ===
+
+# Log file setup
+$logDir = "C:\Eulogy-quest-client-local\Logs"
+$logFileName = "eqlog_Kharvey_Akkas Docker PEQ Installer.txt"
+$logPath = Join-Path $logDir $logFileName
+$expectedMessage = "Welcome to EverQuest!"
+
+Write-Host "Waiting for login confirmation in log..."
+
+# Wait up to 90 seconds
+$maxWait = 90
+$found = $false
+$timer = 0
+
+while (-not $found -and $timer -lt $maxWait) {
+    if (Test-Path $logPath) {
+        $logContent = Get-Content $logPath -Tail 50 -ErrorAction SilentlyContinue
+        foreach ($line in $logContent) {
+            if ($line -like "*$expectedMessage*") {
+                if ($line -match "^\[(.*?)\]") {
+                    $timestampStr = $matches[1]
+                    # Try to parse the log timestamp (format: Wed Mar 27 14:44:29 2025)
+                    $logTimestamp = [datetime]::ParseExact($timestampStr, "ddd MMM d HH:mm:ss yyyy", $null)
+                    if ($logTimestamp -gt $loginStartTime) {
+                        $found = $true
+                        break
+                    }
+                }
+            }
+        }
+    }
+    if (-not $found) {
+        Start-Sleep -Seconds 2
+        $timer += 2
+    }
+}
+
+if ($found) {
+    Write-Host "`n[PASS] Login confirmed: '$expectedMessage' found in log (after script started)."
+} else {
+    Write-Host "`n[FAIL] Login not confirmed within $maxWait seconds."
+}
+
+#// ai-gen end

--- a/.github/workflows/ken/stop-eqemu.ps1
+++ b/.github/workflows/ken/stop-eqemu.ps1
@@ -1,0 +1,34 @@
+#// ai-gen start (ChatGPT-4o, 1)
+# === Config Section ===
+$vmName = "Backup-Eulogy-quest-local-server"
+$vmIp = "192.168.56.103"          # ← Update this
+$vmUser = "sov"                  # ← Update this
+# NOTE: Don't store plain passwords; use key-based auth if possible.
+
+# === Gracefully exit EverQuest ===
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$ahkPath = "C:\Program Files\AutoHotkey\AutoHotkeyU64.exe"
+$exitScript = Join-Path $scriptDir "exitEq.ahk"
+
+Write-Host "Sending /exit to EverQuest client..."
+Start-Process $ahkPath -ArgumentList $exitScript
+Start-Sleep -Seconds 8  # give it a few seconds to log out
+
+# === Stop EQEmu Server ===
+Write-Host "Stopping EQEmu server..."
+
+$remoteCommand = @'
+cd ~/opt/akk-stack
+docker-compose exec -T eqemu-server bash -c 'cd server && ./bin/spire spire:launcher stop'
+sleep 10
+make down
+'@
+
+ssh "$vmUser@$vmIp" $remoteCommand
+Start-Sleep -Seconds 5
+
+# === Stop the VM ===
+Write-Host "Shutting Down the VM..."
+& "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe" controlvm $vmName acpipowerbutton
+
+#// ai-gen end

--- a/.github/workflows/ken/validate-eqemu.ps1
+++ b/.github/workflows/ken/validate-eqemu.ps1
@@ -1,0 +1,45 @@
+#// ai-gen start (ChatGPT-4o, 1)
+
+# Check if the id_rsa key is already loaded
+# We want to pass commands to the VM over ssh, but we need
+# ssh authentication. Ssh authentication needs to be done
+# in an interactive shell (terminal window) and not in a script.
+# Once we authenticate manually on the terminal, adding the key
+# to window's ssh-agent, ssh will not re-ask for the passphrase.
+# (If the passphrase is requested silently in a script, the script will time-out.)
+$keyLoaded = (ssh-add -L 2>$null) -match "ssh-rsa"
+
+if (-not $keyLoaded) {
+    Write-Host "[INFO] Your SSH key is not loaded."
+    Write-Host 'Please run: ssh-add $env:USERPROFILE\.ssh\id_rsa (in a windows terminal) before running this script.'
+    exit 1
+} else {
+    Write-Host "`n[INFO] ssh-agent has the key"
+}
+
+# === Run start script ===
+Write-Host "=== Starting EQEmu server and validating login ==="
+& "$PSScriptRoot\start-eqemu.ps1"
+$startResult = $LASTEXITCODE
+
+if ($startResult -ne 0) {
+    Write-Host "`n[FAIL] start-eqemu.ps1 failed with exit code $startResult"
+    Write-Host "Skipping shutdown."
+    exit $startResult
+}
+
+# === Run stop script ===
+Write-Host "`n=== Shutting down EQEmu server and client ==="
+& "$PSScriptRoot\stop-eqemu.ps1"
+$stopResult = $LASTEXITCODE
+
+# === Final summary ===
+if ($startResult -eq 0) {
+    Write-Host "`n[PASS] EQEmu login validated successfully."
+} else {
+    Write-Host "`n[FAIL] EQEmu validation failed with exit code $startResult"
+}
+
+exit $startResult
+
+#// ai-gen end

--- a/.github/workflows/validate-eqemu.yml
+++ b/.github/workflows/validate-eqemu.yml
@@ -1,0 +1,33 @@
+# //gen-ai start (ChatGPT-4o, 0)
+name: Validate EQEmu Server
+
+on:
+  workflow_dispatch:
+    inputs:
+      user:
+        description: 'Team member folder (e.g., ken, john, maria)'
+        required: true
+        default: 'ken'
+
+jobs:
+  validate:
+    name: Run EQEmu Validation for ${{ github.event.inputs.user }}
+    runs-on: [self-hosted, windows, local-game-server]
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Run validation script from selected user folder
+        shell: pwsh
+        run: |
+          $folder = "${{ github.event.inputs.user }}"
+          $scriptPath = ".github/workflows/$folder/validate-eqemu.ps1"
+          if (-Not (Test-Path $scriptPath)) {
+            Write-Host "[FAIL] Script not found at $scriptPath"
+            exit 1
+          }
+          Write-Host "Running script: $scriptPath"
+          & $scriptPath
+
+# //gen-ai end

--- a/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/README.md
+++ b/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/README.md
@@ -1,0 +1,53 @@
+# Game Server Validation
+
+Follow the instruction guide "game-server-validation.md" located in this directory.
+
+This will get your local GitHub Actions set to validate that your game client is working.
+
+This is an important check, as when we begin making database changes, we might make a change which breaks not only your own server, but anyone's server who pulls your un-verified PR. This catches these types of problems.
+
+# GitHub Workflow Trigger
+│
+├──▶ .github/workflows/validate-eqemu.yml
+│     - Triggers on push or manual dispatch
+│     - Runs on: self-hosted, windows, local-game-server
+│
+├──▶ validate-eqemu.ps1
+│     - Top-level controller
+│     - Calls start-eqemu.ps1
+│     - Waits for login confirmation
+│     - Calls stop-eqemu.ps1 at end
+│
+├──▶ start-eqemu.ps1
+│     - Starts VM: Backup-Eulogy-quest-local-server (via VBoxManage)
+│     - Waits for SSH readiness using `whoami` check
+│     - Starts EQEmu server via SSH:
+│           cd ~/opt/akk-stack && make up && make bash + start
+│     - Waits for at least 25 zone processes to come online
+│     - Launches AutoHotKey login script:
+│
+│       └──▶ login.ahk
+│            - Launches EverQuest via shortcut (includes "patchme")
+│            - Sends keypresses to:
+│                - Accept EULA
+│                - Submit credentials
+│                - Enter server and character
+│            - Uses WinActivate/WinWaitActive to ensure focus
+│
+│     - validate-eqemu.ps1 resumes:
+│         - Monitors eqlog\_Kharvey_*.txt
+│         - Looks for "Welcome to EverQuest!" with a recent timestamp
+│         - Marks login as [PASS] or [FAIL]
+│
+├──▶ stop-eqemu.ps1
+│     - Calls AutoHotKey logout script:
+│
+│       └──▶ exitEq.ahk
+│            - Sends /exit and Enter to log out the character
+│     - SSHes into VM and gracefully shuts down EQEmu server
+│     - Powers off the VM (via VBoxManage)
+│
+└──▶ GitHub Action exits with success/failure code
+      - GitHub UI shows ✅ or ❌
+      - Logs include full PowerShell + AHK output
+

--- a/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/exitEq.ahk
+++ b/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/exitEq.ahk
@@ -1,0 +1,13 @@
+﻿#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+; #Warn  ; Enable warnings to assist with detecting common errors.
+; SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+SendMode, Event
+
+; Bring EverQuest to the foreground
+WinActivate, EverQuest
+WinWaitActive, EverQuest
+Sleep, 500
+
+; Send /exit to trigger logout
+Send, /exit
+Send, {Enter}

--- a/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/game-server-validation-guide.md
+++ b/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/game-server-validation-guide.md
@@ -1,0 +1,136 @@
+# EQEmu GitHub Action: Local Runner Setup Guide
+
+This guide helps team members set up a local GitHub Actions runner to validate EQEmu game server access using the automation scripts in this repo.
+
+---
+
+## ✨ Overview
+This GitHub Action:
+- Starts your local EQEmu server (in a VM)
+- Launches your EverQuest client and logs in
+- Verifies character login via log file
+- Logs out and shuts everything down
+
+Each team member sets up a self-hosted runner to run this check locally.
+
+---
+
+## ✅ 1. Clone the Repo and Locate Scripts
+
+```bash
+git clone git@github.com:your-org/akk-stack.git
+cd akk-stack/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts
+```
+
+This folder contains:
+- `validate-eqemu.ps1` (top-level orchestrator)
+- `start-eqemu.ps1`
+- `stop-eqemu.ps1`
+- `login.ahk`
+- `exitEq.ahk`
+
+---
+
+## ✅ 2. Environment Requirements
+
+Make sure your local machine:
+- Runs **Windows**
+- Has **VirtualBox** installed
+- Has a VM named `Backup-Eulogy-quest-local-server`
+  - (Your VM will likely be named differenty. Adjust the name accordingly in the scripts!)
+- Has your **EQEmu client** at `C:\Eulogy-quest-client-local`
+- Can SSH from Windows to your VM (via `id_rsa`)
+- Has **AutoHotKey v1** installed
+- Has your SSH key loaded: `ssh-add ~/.ssh/id_rsa`
+
+---
+
+## ✅ 3. Install GitHub Actions Runner
+
+From your repo:
+1. Go to **Settings → Actions → Runners → New self-hosted runner**
+2. Choose **Windows**, then follow the steps:
+
+```powershell
+mkdir C:\gh-runner
+cd C:\gh-runner
+Invoke-WebRequest -Uri <URL> -OutFile actions-runner.zip
+Expand-Archive .\actions-runner.zip -DestinationPath .
+.\config.cmd --url https://github.com/your-org/akk-stack --token <token>
+```
+
+During setup:
+- **Runner group**: `local-game-server`
+- **Runner name**: e.g., `John-runner`
+- **Labels**: `windows, local-game-server, eqemu`
+- **Run as service**: `Y`
+- **User account**: your Windows username (e.g., `.\john`)
+
+---
+
+## ✅ 4. Test Your Local Validation Script
+
+Run from your script folder:
+```powershell
+cd path\to\local-game-server-validation-scripts
+.\validate-eqemu.ps1
+```
+
+It should:
+- Start the VM
+- Start the game server
+- Launch EQ and log in
+- Detect success from the log file
+- Log out and shut everything down
+
+---
+
+## ✅ 5. Add Workflow to Your Repo
+
+If not already present, create `.github/workflows/validate-eqemu.yml`:
+
+```yaml
+name: Validate EQEmu Server
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/**'
+
+jobs:
+  validate:
+    runs-on: [self-hosted, windows, local-game-server]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run validation script
+        shell: pwsh
+        run: ./Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/validate-eqemu.ps1
+```
+
+Then:
+```bash
+git add .github/workflows/validate-eqemu.yml
+git commit -m "Add validation workflow"
+git push
+```
+
+---
+
+## ✅ 6. Run the GitHub Action
+
+1. Go to **GitHub Actions** tab
+2. Select **"Validate EQEmu Server"** workflow
+3. Click **"Run workflow"** (manual) or push a change to trigger it
+4. Watch your runner log and the GitHub UI for pass/fail
+
+---
+
+## ✨ Done!
+You're now running automated game-server validation locally via GitHub Actions. Teamwide testing and integration FTW! 🚀
+
+Need help? Ping the team lead.
+

--- a/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/login.ahk
+++ b/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/login.ahk
@@ -1,0 +1,57 @@
+﻿#NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+; #Warn  ; Enable warnings to assist with detecting common errors.
+; SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
+SendMode, Event
+
+; === Make absolutely sure each keypress happens on the EverQuest-focuesd window
+; === Windows loves stealing focus away.
+FocusAndEnter() {
+    WinActivate, EverQuest
+    WinWaitActive, EverQuest
+    Send, {Enter}
+}
+FocusAndTab() {
+    WinActivate, EverQuest
+    WinWaitActive, EverQuest
+    Send, {Tab}
+}
+
+
+; ==== Everquest (eqemu) login automation for the Eulogy project ====
+; == Part of my CI/CD pipeline work ==
+; == Verifies whether the client can log in
+; == after any changes are made to the repo
+
+; === Config ===
+SetWorkingDir, C:\Eulogy-quest-client-local; Ensures a consistent starting directory.
+password := "buzz9099e"
+eqgameShortcut := "Eulogy-local.lnk"
+
+; Launch game client with patchme
+Run, %A_Desktop%\%eqgameShortcut%
+WinWaitActive, EverQuest
+
+Sleep, 3000      ; Wait for EULA screen
+FocusAndTab()    ; Tab away from "Decline" onto "Accept"
+
+Sleep, 1000
+FocusAndEnter()  ; Accept EULA
+
+Sleep, 1000      ; wait for SOE splash screen
+FocusAndEnter()  ; Dismiss SOE splash screen
+
+Sleep, 1000      ; wait for login intro
+FocusAndEnter()  ; Proceed past EQ intro screen
+
+Sleep, 1000      ; wait for actual login screen
+WinActivate, EverQuest
+WinWaitActive, EverQuest
+Send, %password%
+Sleep, 500
+FocusAndEnter()  ; Submit login password
+
+Sleep, 1000
+FocusAndEnter()  ; Select server
+
+Sleep, 20000     ; Long wait just in case loading takes a long time
+FocusAndEnter()  ; Log in with a character

--- a/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/start-eqemu.ps1
+++ b/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/start-eqemu.ps1
@@ -1,0 +1,150 @@
+#// ai-gen start (ChatGPT-4o, 1)
+# === Config Section ===
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$vmName = "Backup-Eulogy-quest-local-server"
+$vmIp = "192.168.56.103"          # ← Update this
+$vmUser = "sov"                  # ← Update this
+# NOTE: Don't store plain passwords; use key-based auth if possible.
+
+# === Start the VM ===
+Write-Host "Starting VM..."
+& "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe" startvm $vmName --type headless
+Start-Sleep -Seconds 10
+
+# === Wait for SSH to become available ===
+Write-Host "Waiting for SSH connectivity..."
+
+$sshReady = $false
+$maxSshWait = 90
+$sshTimer = 0
+
+while (-not $sshReady -and $sshTimer -lt $maxSshWait) {
+    try {
+        $sshTest = & ssh -o ConnectTimeout=3 -o StrictHostKeyChecking=no "$vmUser@$vmIp" "whoami"
+        Write-Host "SSH output: '$sshTest'"
+        if ($sshTest -match "$vmUser") {
+            $sshReady = $true
+            break
+        }
+    } catch {
+        Write-Host "SSH failed: $_"
+    }
+
+    Start-Sleep -Seconds 3
+    $sshTimer += 3
+    Write-Host "  ...still waiting for SSH ($sshTimer seconds)"
+}
+
+if (-not $sshReady) {
+    Write-Host "[FAIL] SSH did not become available after $maxSshWait seconds."
+    exit 1
+}
+
+Write-Host "[PASS] SSH is now available on the VM."
+
+# === Start EQEmu Server ===
+Write-Host "Starting EQEmu server inside VM..."
+$remoteCommand = @'
+cd ~/opt/akk-stack
+make up
+sleep 10
+docker-compose exec -T eqemu-server bash -c 'cd server && ./bin/spire spire:launcher start'
+'@
+
+ssh "$vmUser@$vmIp" $remoteCommand
+
+# === Wait for the world server (and zones!) to finish loading before running login.ahk
+Write-Host "Waiting for zones to come online..."
+
+$ready = $false
+$timeout = 120  # total wait time in seconds
+$waitTime = 0
+
+while (-not $ready -and $waitTime -lt $timeout) {
+    $zoneCountOutput = ssh "$vmUser@$vmIp" "ps aux | grep -v grep | grep '/home/eqemu/server/bin/zone' | wc -l"
+    $zoneCount = [int]$zoneCountOutput.Trim()
+    
+    if ($zoneCount -ge 25) {
+        $ready = $true
+        break
+    }
+
+    Start-Sleep -Seconds 3
+    $waitTime += 3
+    Write-Host "Zones online: $zoneCount (waiting for at least 25)..."
+}
+
+if ($ready) {
+    Write-Host "[PASS] Zone processes are online ($zoneCount total)."
+} else {
+    Write-Host "[FAIL] Zone processes did not reach expected count within $timeout seconds."
+    exit 1
+}
+
+# === Launch and Auto-Login EQ Client ===
+Write-Host "Launching AutoHotKey login script..."
+$ahkScript = Join-Path $scriptDir "login.ahk"
+$ahkPath = "C:\Program Files\AutoHotkey\AutoHotkeyU64.exe"
+# debug
+Write-Host "AHK Path: $ahkPath"
+Write-Host "Script Path: $ahkScript"
+# /debug
+
+# === Launch the login ahk script ===
+# But, first we log the time before the ahk script is run
+# Then we run the ahk script
+# Then we wait 70 seconds before continuing this PowerShell script
+# As the next three lines occur here nearly simultaneously
+$loginStartTime = Get-Date
+
+Start-Process $ahkPath -ArgumentList $ahkScript
+
+Start-Sleep -Seconds 70
+# This give us 70 seconds for "Start-Process $ahkPath -ArgumentList $ahkScript"
+# to run before the rest of this file executes.
+
+# === Confirm Login via Log File with Timestamp Validation ===
+
+# Log file setup
+$logDir = "C:\Eulogy-quest-client-local\Logs"
+$logFileName = "eqlog_Kharvey_Akkas Docker PEQ Installer.txt"
+$logPath = Join-Path $logDir $logFileName
+$expectedMessage = "Welcome to EverQuest!"
+
+Write-Host "Waiting for login confirmation in log..."
+
+# Wait up to 90 seconds
+$maxWait = 90
+$found = $false
+$timer = 0
+
+while (-not $found -and $timer -lt $maxWait) {
+    if (Test-Path $logPath) {
+        $logContent = Get-Content $logPath -Tail 50 -ErrorAction SilentlyContinue
+        foreach ($line in $logContent) {
+            if ($line -like "*$expectedMessage*") {
+                if ($line -match "^\[(.*?)\]") {
+                    $timestampStr = $matches[1]
+                    # Try to parse the log timestamp (format: Wed Mar 27 14:44:29 2025)
+                    $logTimestamp = [datetime]::ParseExact($timestampStr, "ddd MMM d HH:mm:ss yyyy", $null)
+                    if ($logTimestamp -gt $loginStartTime) {
+                        $found = $true
+                        break
+                    }
+                }
+            }
+        }
+    }
+    if (-not $found) {
+        Start-Sleep -Seconds 2
+        $timer += 2
+    }
+}
+
+if ($found) {
+    Write-Host "`n[PASS] Login confirmed: '$expectedMessage' found in log (after script started)."
+} else {
+    Write-Host "`n[FAIL] Login not confirmed within $maxWait seconds."
+}
+
+#// ai-gen end

--- a/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/stop-eqemu.ps1
+++ b/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/stop-eqemu.ps1
@@ -1,0 +1,34 @@
+#// ai-gen start (ChatGPT-4o, 1)
+# === Config Section ===
+$vmName = "Backup-Eulogy-quest-local-server"
+$vmIp = "192.168.56.103"          # ← Update this
+$vmUser = "sov"                  # ← Update this
+# NOTE: Don't store plain passwords; use key-based auth if possible.
+
+# === Gracefully exit EverQuest ===
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$ahkPath = "C:\Program Files\AutoHotkey\AutoHotkeyU64.exe"
+$exitScript = Join-Path $scriptDir "exitEq.ahk"
+
+Write-Host "Sending /exit to EverQuest client..."
+Start-Process $ahkPath -ArgumentList $exitScript
+Start-Sleep -Seconds 8  # give it a few seconds to log out
+
+# === Stop EQEmu Server ===
+Write-Host "Stopping EQEmu server..."
+
+$remoteCommand = @'
+cd ~/opt/akk-stack
+docker-compose exec -T eqemu-server bash -c 'cd server && ./bin/spire spire:launcher stop'
+sleep 10
+make down
+'@
+
+ssh "$vmUser@$vmIp" $remoteCommand
+Start-Sleep -Seconds 5
+
+# === Stop the VM ===
+Write-Host "Shutting Down the VM..."
+& "C:\Program Files\Oracle\VirtualBox\VBoxManage.exe" controlvm $vmName acpipowerbutton
+
+#// ai-gen end

--- a/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/validate-eqemu.ps1
+++ b/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/validate-eqemu.ps1
@@ -1,0 +1,45 @@
+#// ai-gen start (ChatGPT-4o, 1)
+
+# Check if the id_rsa key is already loaded
+# We want to pass commands to the VM over ssh, but we need
+# ssh authentication. Ssh authentication needs to be done
+# in an interactive shell (terminal window) and not in a script.
+# Once we authenticate manually on the terminal, adding the key
+# to window's ssh-agent, ssh will not re-ask for the passphrase.
+# (If the passphrase is requested silently in a script, the script will time-out.)
+$keyLoaded = (ssh-add -L 2>$null) -match "ssh-rsa"
+
+if (-not $keyLoaded) {
+    Write-Host "[INFO] Your SSH key is not loaded."
+    Write-Host 'Please run: ssh-add $env:USERPROFILE\.ssh\id_rsa (in a windows terminal) before running this script.'
+    exit 1
+} else {
+    Write-Host "`n[INFO] ssh-agent has the key"
+}
+
+# === Run start script ===
+Write-Host "=== Starting EQEmu server and validating login ==="
+& "$PSScriptRoot\start-eqemu.ps1"
+$startResult = $LASTEXITCODE
+
+if ($startResult -ne 0) {
+    Write-Host "`n[FAIL] start-eqemu.ps1 failed with exit code $startResult"
+    Write-Host "Skipping shutdown."
+    exit $startResult
+}
+
+# === Run stop script ===
+Write-Host "`n=== Shutting down EQEmu server and client ==="
+& "$PSScriptRoot\stop-eqemu.ps1"
+$stopResult = $LASTEXITCODE
+
+# === Final summary ===
+if ($startResult -eq 0) {
+    Write-Host "`n[PASS] EQEmu login validated successfully."
+} else {
+    Write-Host "`n[FAIL] EQEmu validation failed with exit code $startResult"
+}
+
+exit $startResult
+
+#// ai-gen end


### PR DESCRIPTION
## [Overview](#overview)
### Issue
Each team member aught to feel secure knowing that any change to the repo they wish to upload to the group-4-upstream repository does not break their (or anyone else's) ability to access their client/server environment (up to and including being able to log into their locally-hosted game).

Therefore, there needs to be a check (via GitHub Actions) which validates that their game-server is still able to be accessed via their game client. This action, when ran on each PR, should show a success message indicating that this validation has been successfully ran. **Only** on a successful game-server validation should the PR be green-lit for PR accept/merge.

### This Solution
GitHub Actions workflow with documentation.
The required scripts and the guide for their installation are in this PR. The scripts are found both in the documentation directory at `akk-stack/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts` and for use within the workflow at `.github/workflows/ken`. The documentation directory also comes with `game-server-validation-guide.md` and `README.md` which detail what is happening with the GitHub Action and the scripts. Additionally, they document how to set this up for individual team members on their own, as required (everyone has a different name for their VM, for example). Each team member needs to set up their own directory `.github/workflow/<name>` to execute what GitHub calls "Local Runners". The team member copies the **script** files from `akk-stack/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/` (BUT not the `.md` documentation files), and pastes these scripts into their own `.github/workflow/<name>` directory. These pasted files need to be edited to change the basic things like their VM name and their **own** username (instead of mine). The included documentation covers what the user must do on their own machine to accomplish this. Only the team member is allowed (for example) to create a **Windows Service**, which is part of the requirement for this GitHub Local Runner (and is documented).

### This Solution's workflow diagram
GitHub Workflow Trigger
│
├──▶ .github/workflows/validate-eqemu.yml
│     - Triggers on push or manual dispatch
│     - Runs on: self-hosted, windows, local-game-server
│
├──▶ validate-eqemu.ps1
│     - Top-level controller
│     - Calls start-eqemu.ps1
│     - Waits for login confirmation
│     - Calls stop-eqemu.ps1 at end
│
├──▶ start-eqemu.ps1
│     - Starts VM: Backup-Eulogy-quest-local-server (via VBoxManage)   $${\color{red}Change \space my \space VM \space name \space to \space your \space VM's \space name!}$$
│     - Waits for SSH readiness using `whoami` check
│     - Starts EQEmu server via SSH:
│           cd ~/opt/akk-stack && make up && make bash + start
│     - Waits for at least 25 zone processes to come online
│     - Launches AutoHotKey login script:
│
│       └──▶ login.ahk
│            - Launches EverQuest via shortcut (includes "patchme")
│            - Sends keypresses to:
│                - Accept EULA
│                - Submit credentials
│                - Enter server and character
│            - Uses WinActivate/WinWaitActive to ensure focus
│
│     - validate-eqemu.ps1 resumes:
│         - Monitors eqlog_Kharvey_*.txt  $${\color{red}Change \space Kharvey \space to \space your \space in \space game \space name!}$$
│         - Looks for "Welcome to EverQuest!" with a recent timestamp
│         - Marks login as [PASS] or [FAIL]
│
├──▶ stop-eqemu.ps1
│     - Calls AutoHotKey logout script:
│
│       └──▶ exitEq.ahk
│            - Sends /exit and Enter to log out the character
│     - SSHes into VM and gracefully shuts down EQEmu server
│     - Powers off the VM (via VBoxManage)
│
└──▶ GitHub Action exits with success/failure code
      - GitHub UI shows ✅ or ❌
      - Logs include full PowerShell + AHK output

## Other Notes

1. To test that this GitHub Action works, I need to Push this and test it first. Additional PR's might follow if needed to get this working correctly. I will also upload a ppx/pdf which depicts the setup.
2. Five files are duplicated once. The second set of the 5 are placed into documentation for reference and copying. So, this PR actually pushes 8 distinct files to accomplish this task.
3. The five scripts cannot be combined into one script because they are a combination of PowerShell and AutoHotKey, and ran in a timed manner, alternating between `.ps1` and `.ahk` scripts. The `.ps1` script would still need the `ahk` scripts to exist. As a side-benefit, they can be ran independently if needed.

## Issue Triage
Closes #70 

I will open another issue (as a **Bugfix**) if the GitHub Action doesn't immediately work, and link it to the closed 70 issue. I wouldn't normally close without testing, but here we're testing the tester, and that needs to be put up first.

## [YouTrack Ticket](#tickets)
- [EUL-116](https://eulogy-quest.youtrack.cloud/issue/EUL-116) Game-server CI/CD check via GitHub Actions

![image](https://github.com/user-attachments/assets/10ee9f75-e7a3-4d10-b19b-bca1616542ab)

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/70



