### PR TITLE
Still on bugfix 117

### DIFF
--- a/.github/workflows/ken/validate-eqemu.ps1
+++ b/.github/workflows/ken/validate-eqemu.ps1
@@ -7,15 +7,13 @@
 # Once we authenticate manually on the terminal, adding the key
 # to window's ssh-agent, ssh will not re-ask for the passphrase.
 # (If the passphrase is requested silently in a script, the script will time-out.)
-$keyLoaded = (ssh-add -L 2>$null) -match "ssh-rsa"
 
-if (-not $keyLoaded) {
-    Write-Host "[INFO] Your SSH key is not loaded."
-    Write-Host 'Please run: ssh-add $env:USERPROFILE\.ssh\id_rsa (in a windows terminal) before running this script.'
+$keyCheck = ssh-add -L 2>&1
+if ($keyCheck -match "The agent has no identities") {
+    Write-Host "[FAIL] SSH key not loaded. Run: ssh-add $env:USERPROFILE\.ssh\id_rsa"
     exit 1
-} else {
-    Write-Host "`n[INFO] ssh-agent has the key"
 }
+# Note: this can silently fail if the id_rsa key is needed, but another key is loaded.
 
 # === Run start script ===
 Write-Host "=== Starting EQEmu server and validating login ==="

--- a/.github/workflows/validate-eqemu.yml
+++ b/.github/workflows/validate-eqemu.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run validation script from selected user folder
-        shell: powershell
+        shell: pwsh
         run: |
           $folder = "${{ github.event.inputs.user }}"
           $scriptPath = ".github/workflows/$folder/validate-eqemu.ps1"

--- a/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/validate-eqemu.ps1
+++ b/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/validate-eqemu.ps1
@@ -7,15 +7,13 @@
 # Once we authenticate manually on the terminal, adding the key
 # to window's ssh-agent, ssh will not re-ask for the passphrase.
 # (If the passphrase is requested silently in a script, the script will time-out.)
-$keyLoaded = (ssh-add -L 2>$null) -match "ssh-rsa"
 
-if (-not $keyLoaded) {
-    Write-Host "[INFO] Your SSH key is not loaded."
-    Write-Host 'Please run: ssh-add $env:USERPROFILE\.ssh\id_rsa (in a windows terminal) before running this script.'
+$keyCheck = ssh-add -L 2>&1
+if ($keyCheck -match "The agent has no identities") {
+    Write-Host "[FAIL] SSH key not loaded. Run: ssh-add $env:USERPROFILE\.ssh\id_rsa"
     exit 1
-} else {
-    Write-Host "`n[INFO] ssh-agent has the key"
 }
+# Note: this can silently fail if the id_rsa key is needed, but another key is loaded.
 
 # === Run start script ===
 Write-Host "=== Starting EQEmu server and validating login ==="


### PR DESCRIPTION
## [Overview](#overview)
Updated validate-eqemu.ps1 (and its documentation copy). Accidentally deleted validate-eqemu.yml, re-added it.
Changed validate-eqemu.ps1 to not ask for ssh-add, as ssh-add re-prompts no matter whether it is loaded or not, and logic to discover whether it is loaded is limited and buggy. This hangs a non-interactive shell, and therefore GitHub Actions.

## [YouTrack Ticket](#tickets)
- [EUL-117](https://eulogy-quest.youtrack.cloud/issue/EUL-117) GitHub Action Validate-EQEmu (Bugfix)

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/72
