### PR TITLE
Increased ssh login timout to 180 seconds

### DIFF
--- a/.github/workflows/ken/start-eqemu.ps1
+++ b/.github/workflows/ken/start-eqemu.ps1
@@ -15,7 +15,7 @@ Start-Sleep -Seconds 10
 Write-Host "Waiting for SSH connectivity..."
 
 $sshReady = $false
-$maxSshWait = 90
+$maxSshWait = 180
 $sshTimer = 0
 
 while (-not $sshReady -and $sshTimer -lt $maxSshWait) {

--- a/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/start-eqemu.ps1
+++ b/Eulogy-Quest/eulogy-docs/local-game-server-validation-scripts/start-eqemu.ps1
@@ -15,7 +15,7 @@ Start-Sleep -Seconds 10
 Write-Host "Waiting for SSH connectivity..."
 
 $sshReady = $false
-$maxSshWait = 90
+$maxSshWait = 180
 $sshTimer = 0
 
 while (-not $sshReady -and $sshTimer -lt $maxSshWait) {


### PR DESCRIPTION
## [Overview](#overview)
The GitHub Action Local Runner calls startup-eqemu.ps1, and there we wait for ssh connection and time-out if ssh isn't available after a time. I'm increasing this time-out to 180 seconds.

## [YouTrack Ticket](#tickets)
- [EUL-117](https://eulogy-quest.youtrack.cloud/issue/EUL-117) GitHub Action Validate-EQEmu (Bugfix)

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/72
