### PR TITLE
[EUL-129] Fixed issue with UML not appearing in PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 _<What changed? Why?>_
 
 ## [Diagram](#diagram)
-![Diagram](images/System_Overview.jpeg)
+![Diagram](https://raw.githubusercontent.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/master/.github/images/System_Overview.jpeg)
 
 ## [YouTrack Ticket](#tickets)
 - https://eulogy-quest.youtrack.cloud/issue/EUL-ISSUENUMBER


### PR DESCRIPTION
## [Overview](#overview)
Prior to this PR, the default UML diagram would not appear in the pull request template despite it seemingly working when I first added it. 
I have changed the link from a relative path to a url to ensure that it appears; I've used the url in the pr template in: this PR, the GitHub Issue, and the YouTrack card, and the UML appears in all 3 locations.

## [Diagram](#diagram)
![Diagram](https://raw.githubusercontent.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/master/.github/images/System_Overview.jpeg)

## [YouTrack Ticket](#tickets)
- https://eulogy-quest.youtrack.cloud/issue/EUL-129

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/105
- Closes #105 
