### PR TITLE
[EUL 153] Implement getting NPC _task.txt files from quest directory - Hardy Fenam

### DIFF
--- a/Eulogy-Quest/GPT/perl-script-NPCs.py
+++ b/Eulogy-Quest/GPT/perl-script-NPCs.py
@@ -60,12 +60,24 @@ def main():
     tutorialb_dir = Path(__file__).parent.parent.parent / "server" / "quests" / "tutorialb"
     tutorialb_dir.mkdir(parents=True, exist_ok=True)
 
-    for npc in npc_names:
+    for index, npc in enumerate(npc_names):
+
+        #try to find quest text for this npc (npc1_task.txt, npc2_task.txt, etc)
+        file_name = f"npc{index}_task.txt" if index != 0 else "ghost_task.txt"
+        npc_task_path = quest_dir / file_name
+
+        if npc_task_path.exists():
+            quest_text = npc_task_path.read_text(encoding="utf-8").strip()
+            print(f"Using specific quest text for {npc}. file: {file_name}")
+        else:
+            quest_text = quest_text_dump
+            print(f"No custom quest text found for {npc}. Using default quest text.")
+
         output_path = perl_dir / f"{npc}.pl"
         perl_script = f"""
 sub EVENT_SAY {{
   if ($text=~/hail/i) {{
-      quest::say(\"{quest_text_dump}\");
+      quest::say(\"{quest_text}\");
   }}
 }}
 """


### PR DESCRIPTION
## [Overview](#overview)
Files Changed:
perl-script-NPCs.py

the ```perl-script-NPCs.py``` script adds dialogue to NPCs. I modified the loop that gives NPCs their 'hail' command dialogue. 
the loop will:
-  try to find a "_task.txt" quest text file from the specified quests' directory. 
- Then read from that "_task.txt" file and create a 'hail' command from it.

NPC quest text files for the MVP quest can be named one of the following:
- ghost_task.txt, npc1_task.txt, npc2_task.txt, npc3_task.txt, npc4_task.txt

If a "_task.txt" file is not found, it will default to using text specified in the ```quest_text_dump``` variable. At this point 'ghost_task.txt' is the default file in ```quest_text_dump```.

## [Diagram](#diagram)
![Diagram](https://raw.githubusercontent.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/master/.github/images/System_Overview.jpeg)

## [Screenshots](#screenshots)
Console output from ```python3 create-story.py Alan\ Turing```
![ss_quests](https://github.com/user-attachments/assets/0d1dc0aa-8839-499c-b840-8bc757774ca5)

Screenshot in-game showing hail command output for 2 NPCs (Alan Turing and High Priestess):
both show same dialogue (expected), as there is only 'ghost_task.txt' implemented and no 'npc1_task.txt' as of now.
<img width="722" alt="Screenshot 2025-04-28 at 2 28 54 AM" src="https://github.com/user-attachments/assets/ee2a3222-55f0-439a-b087-005b4e6ea432" />


## [YouTrack Ticket](#tickets)
- https://eulogy-quest.youtrack.cloud/issue/EUL-ISSUENUMBER

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/ISSUENUMBER
