### PR TITLE
Added super linter for to lint remaining languages

### DIFF
--- a/.github/workflows/super_linter.yml
+++ b/.github/workflows/super_linter.yml
@@ -1,0 +1,35 @@
+name: Super Linter
+
+on:
+  pull_request:
+    branches: [master]
+
+permissions: {}
+
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
+
+      - name: Run Super-linter
+        uses: super-linter/super-linter@v7.3.0
+        env:
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: false   # Only lint changed files
+          VALIDATE_LUA: false   # Already have a Lua linter
+          VALIDATE_PERL: false  # Already have a Perl linter


### PR DESCRIPTION
## [Overview](#overview)
We have a number that our current linters do not check, so I added the [super linter](https://github.com/super-linter/super-linter) to our GitHub workflow. This will check the python, javascript, and other files that we have used in our project. It is also able to check Perl and Lua files, but I have disabled these since they are already covered.

Added file
- super_linter.yml

## [Diagram](#diagram)
![Activity diagram of workflow (6)](https://github.com/user-attachments/assets/2264f899-2a33-430f-ad1d-79a2ff53924d)

## [YouTrack Ticket](#tickets)
- https://eulogy-quest.youtrack.cloud/issue/EUL-154

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/144
