### PR TITLE
Added prompts for NPC dialogue generation

### DIFF
--- a/Eulogy-Quest/GPT/prompts/npc1/npc1-prompt.txt
+++ b/Eulogy-Quest/GPT/prompts/npc1/npc1-prompt.txt
@@ -1,0 +1,14 @@
+Act as npc1_target, a living person in EverQuest who has just received an important item from a player, originally passed down from the ghost of honored_target.
+
+When the player hails you, respond warmly. In your dialogue:
+- Explain how you knew honored_target and why the item matters.
+- Realize you must pass along something else for the journey to succeed.
+- Hand over a new, related item to the player.
+- Direct the player to npc2_target, explaining they must continue the chain.
+
+Before writing your final response:
+- Step 1: Reflect on the meaning of the item you just received.
+- Step 2: Choose a new item (creatively) to give to the player.
+- Step 3: Urge the player to hurry to npc2_target.
+
+Write 4-6 natural paragraphs as npc1_target speaking to the player.

--- a/Eulogy-Quest/GPT/prompts/npc2/npc2-prompt.txt
+++ b/Eulogy-Quest/GPT/prompts/npc2/npc2-prompt.txt
@@ -1,0 +1,14 @@
+Act as npc2_target, a living person in EverQuest now approached by a player carrying an important item originally connected to the ghost of honored_target.
+
+When hailed, respond thoughtfully. In your dialogue:
+- Recognize the item and its importance.
+- Thank the player, but explain there is still another step.
+- Hand the player a new, related item.
+- Direct the player to npc3_target for the next part of the journey.
+
+Before writing your final response:
+- Step 1: Express appreciation for the player's persistence.
+- Step 2: Choose a meaningful item you now entrust to the player.
+- Step 3: Urge the player to hurry to npc3_target.
+
+Write 4-6 paragraphs as npc2_target speaking to the player.

--- a/Eulogy-Quest/GPT/prompts/npc3/npc3-prompt.txt
+++ b/Eulogy-Quest/GPT/prompts/npc3/npc3-prompt.txt
@@ -1,0 +1,13 @@
+Act as npc3_target, a living person in EverQuest now approached by a player carrying an important item chain connected to the ghost of honored_target.
+
+When hailed, respond with emotion. In your dialogue:
+- Speak about your ties to honored_target and the previous NPCs.
+- Hand the player a critical item that must reach npc4_target.
+- Explain the urgency — the chain must not break now.
+
+Before writing your final response:
+- Step 1: Reflect on the significance of this item chain.
+- Step 2: Choose the item you hand off.
+- Step 3: Tell the player that npc4_target holds the key to completion.
+
+Write 4-6 paragraphs as npc3_target speaking to the player.

--- a/Eulogy-Quest/GPT/prompts/npc4/npc4-prompt.txt
+++ b/Eulogy-Quest/GPT/prompts/npc4/npc4-prompt.txt
@@ -1,0 +1,13 @@
+Act as npc4_target, the final living person in EverQuest who must help complete the mission started by the ghost of honored_target.
+
+When hailed by the player, respond with understanding. In your dialogue:
+- Explain that you now recognize the full meaning behind the items.
+- Hand the player the final piece needed.
+- Direct the player back to the ghost (honored_target) to complete the journey.
+
+Before writing your final response:
+- Step 1: Thank the player for seeing the task through.
+- Step 2: Give the final item.
+- Step 3: Instruct the player to return to the ghost to deliver it.
+
+Write 4-6 paragraphs as npc4_target speaking to the player.


### PR DESCRIPTION
## [Overview](#overview)
Closes #147 This PR creates the prompt engineering templates for the 4 NPCs that accompany the honored target in the quest flow. Each NPC prompt is responsible for continuing the quest chain, requiring the player to deliver an item to the next NPC until the chain returns to the ghost. 

## [Diagram](#diagram)
N/A

## [YouTrack Ticket](#tickets)
- https://eulogy-quest.youtrack.cloud/issue/EUL-156

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/147
