### PR TITLE
[EUL 157] modify base-story.py (add to prompt for ghost) - Hardy Fenam

### DIFF
--- a/Eulogy-Quest/GPT/base-story.py
+++ b/Eulogy-Quest/GPT/base-story.py
@@ -73,13 +73,15 @@ def main():
     # Construct AI prompt
     prompt = (
         f"You are the ghost of {honored_target} in the world of EverQuest. "
-        "A player has initiated conversation with you. Identify four pieces of information:\n\n"
+        "A player has initiated conversation with you. Identify six pieces of information:\n\n"
         "1. Provide 'ghost_task.txt' describing only the delivery task, its importance, "
         "the item to deliver, the recipient, and the exact EverQuest zone (valid through Planes of Power). "
         "This is internal-use only.\n\n"
         "2. Provide 'ghost_delivery_item.txt' containing only the item name.\n\n"
         "3. Provide 'ghost_delivery_target.txt' containing only the recipient's two-word name.\n\n"
         "4. Provide 'ghost_delivery_target_location.txt' containing only the zone name where the recipient is located.\n"
+        "5. Provide 'ghost_dialog.txt' containing a short in-character paragraph where the ghost explains the quest to the player\n\n"
+        "6. Provide 'ghost_reward.txt' containing only a reward item name (no description, only the name). The ghost doesnt know about this item.\n"
     )
 
     # Query GPT
@@ -100,7 +102,9 @@ def main():
         'ghost_task': [],
         'ghost_delivery_item': [],
         'ghost_delivery_target': [],
-        'ghost_delivery_target_location': []
+        'ghost_delivery_target_location': [],
+        'ghost_dialog': [],
+        'ghost_reward': []
     }
     current = None
     for line in content.splitlines():
@@ -112,6 +116,10 @@ def main():
             current = 'ghost_delivery_target'; continue
         if 'ghost_delivery_target_location.txt' in line:
             current = 'ghost_delivery_target_location'; continue
+        if 'ghost_dialog.txt' in line:
+            current = 'ghost_dialog'; continue
+        if 'ghost_reward.txt' in line:
+            current = 'ghost_reward'; continue
         if current:
             sections[current].append(line)
 
@@ -120,7 +128,9 @@ def main():
         'ghost_task': 'ghost_task.txt',
         'ghost_delivery_item': 'ghost_delivery_item.txt',
         'ghost_delivery_target': 'ghost_delivery_target.txt',
-        'ghost_delivery_target_location': 'ghost_delivery_target_location.txt'
+        'ghost_delivery_target_location': 'ghost_delivery_target_location.txt',
+        'ghost_dialog': 'ghost_dialog.txt',
+        'ghost_reward': 'ghost_reward.txt'
     }
     for key, fname in filenames.items():
         file_path = build_dir / fname


### PR DESCRIPTION
## [Overview](#overview)
Files changed:
base-story.py

```base-story.py``` runs the openai prompt for creating the required elements (items, NPCs(_target), dialog, task).
I added 2 new elements missing from ghost elements:
- ghost_dialog.py
  -  prompt for ghost_dialog.py: Provide 'ghost_dialog.txt' containing a short in-character paragraph where the ghost explains the quest to the player.
- ghost_reward.py
  - prompt for ghost_reward.py: Provide 'ghost_reward.txt' containing only a reward item name (no description, only the name). The ghost doesnt know about this item.

This completes the required elements for the ghost NPC.

## [Diagram](#diagram)
![Diagram](https://raw.githubusercontent.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/master/.github/images/System_Overview.jpeg)

## [Screenshots](#screenshots)
Screenshot showing console output. shows exact text written to 'ghost_dialog.txt' and 'ghost_reward.txt'
ran: ```python3 create-quest.py Thomas\ Edison```
![scsc2](https://github.com/user-attachments/assets/467e2089-3987-4616-a13e-afc02e28eed2)

Screenshot to verify generated files in correct directory
![scsc](https://github.com/user-attachments/assets/52d61430-b5fe-47a7-bab8-1dbc80c908cd)



## [YouTrack Ticket](#tickets)
- https://eulogy-quest.youtrack.cloud/issue/EUL-ISSUENUMBER

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/ISSUENUMBER
