### PR TITLE
Updated GitHub Action Local Runner script start-eqemu.ps1

### DIFF
--- a/.github/workflows/ken/login.ahk
+++ b/.github/workflows/ken/login.ahk
@@ -1,8 +1,8 @@
-﻿MsgBox, login.ahk is running!
+﻿;MsgBox, login.ahk is running!
 #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
 ; #Warn  ; Enable warnings to assist with detecting common errors.
 ; SendMode Input  ; Recommended for new scripts due to its superior speed and reliability.
-SendMode, Event
+;SendMode, Event
 
 ;// ai-gen start (ChatGPT-4o, 1)
 

--- a/.github/workflows/ken/start-eqemu.ps1
+++ b/.github/workflows/ken/start-eqemu.ps1
@@ -64,7 +64,10 @@ while (-not $ready -and $waitTime -lt $timeout) {
     $zoneCountOutput = ssh "$vmUser@$vmIp" "ps aux | grep -v grep | grep '/home/eqemu/server/bin/zone' | wc -l"
     $zoneCount = [int]$zoneCountOutput.Trim()
     
-    if ($zoneCount -ge 25) {
+# was waiting for 25 of 30 zones, but now my local worldserver only brings up an
+# initial 10 for some reason.
+
+    if ($zoneCount -ge 10) {
         $ready = $true
         break
     }


### PR DESCRIPTION
## [Overview](#overview)
Server Validation GitHub Actions Local Runner was failing due to the check for 25 zones being online before
attempting login was failing. For some reason, my local server now only brings up 10 zones before considering itself
ready for login. So I'm updating this count to 10 and will test it. I have to merge in order to test.

The rush on last minute PRs really necessitate this validation tool. I don't have time to fix a broken server.

Commit message:
I reduced necessary zone count to 10; removed login.ahk sanity messagebox. Zone count of 25 was used as an indicator that enough zones were online to attempt logging in. For some reason the worldserver now only brings up 10 and calls it ready. No obvious setting for 'minimum zone count on startup', only the basic zone/port allowance in .env

## [Diagram](#diagram)
N/A

