### PR TITLE
[EUL-155] Added tests for create-quest, perl-script-NPCs, and watch_triggers

### DIFF
--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,55 @@
+name: Test Coverage
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'website/**/*.py'   # Consider updating to run with any file change
+      - 'tests/**/*.py'
+      - 'Eulogy-Quest/GPT/**/*.py'
+      - '.github/workflows/test-coverage.yml'
+      - 'Eulogy-Quest/GPT/Holliday-quest/src/perl/**/*.py'
+  pull_request:
+    branches: [ master ]
+    paths:
+      - 'website/**/*.py'
+      - 'tests/**/*.py'
+      - 'Eulogy-Quest/GPT/**/*.py'
+      - '.github/workflows/test-coverage.yml'
+      - 'Eulogy-Quest/GPT/Holliday-quest/src/perl/**/*.py'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      # Check if pytest-mock is needed
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov
+          pip install -r website/server/requirements.txt
+          pip install watchdog
+
+      - name: Run tests with coverage
+        run: |
+          PYTHONPATH=. pytest \
+            --cov=Eulogy-Quest/GPT \
+            --cov=website \
+            --cov=Eulogy-Quest/GPT/Holliday-quest/src/perl \
+            --cov-report=term-missing \
+            tests/
+            
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+

--- a/tests/test_create-quest.py
+++ b/tests/test_create-quest.py
@@ -1,0 +1,65 @@
+# ai-gen start (ChatGPT-4, 1)
+import unittest
+from unittest.mock import patch, call
+import subprocess
+import importlib.util
+import os
+import sys
+
+file_path = os.path.abspath("Eulogy-Quest/GPT/create-quest.py")
+spec = importlib.util.spec_from_file_location("create_quest", file_path)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class TestCreateQuest(unittest.TestCase):
+    def test_missing_arguments(self):
+        with patch.object(sys, "argv", ["create-quest.py"]), \
+             self.assertRaises(SystemExit) as cm, \
+             patch("builtins.print") as mock_print:
+            module.main()
+
+        self.assertEqual(cm.exception.code, 1)
+        mock_print.assert_any_call("Usage: python3 create-quest.py <honored_target> [zone]")
+
+    def test_invalid_name_format(self):
+        with patch.object(sys, "argv", ["create-quest.py", "OneName"]), \
+             self.assertRaises(SystemExit) as cm, \
+             patch("builtins.print") as mock_print:
+            module.main()
+        self.assertEqual(cm.exception.code, 1)
+        mock_print.assert_any_call("Error: honored_target must be two words (first and last name)")
+
+    def test_invalid_zone(self):
+        with patch.object(sys, "argv", ["create-quest.py", "Test User", "invalid_zone"]), \
+             self.assertRaises(SystemExit) as cm, \
+             patch("builtins.print") as mock_print:
+            module.main()
+        self.assertEqual(cm.exception.code, 1)
+        mock_print.assert_any_call("Error: zone must be 'tutorialb' or 'world-wide'")
+
+    @patch("subprocess.run")
+    @patch("builtins.print")
+    def test_valid_execution_flow(self, mock_print, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+
+        with patch.object(sys, "argv", ["create-quest.py", "Test User", "tutorialb"]):
+            module.main()
+
+        self.assertEqual(mock_run.call_count, 3)
+
+        # Collect the actual bash command strings
+        bash_commands = [call_args[0][0][2] for call_args in mock_run.call_args_list]
+
+        script_dir = module.Path(module.__file__).parent.resolve()
+        expected_commands = [
+            f"source ../.venv/bin/activate && python3 {script_dir / 'base-story.py'} 'Test User'",
+            f"source ../.venv/bin/activate && python3 {script_dir / 'updateNPCs.py'} 'User-quest'",
+            f"source ../.venv/bin/activate && python3 {script_dir / 'perl-script-NPCs.py'} 'Test User' 'tutorialb'",
+        ]
+
+        for expected, actual in zip(expected_commands, bash_commands):
+            self.assertEqual(expected, actual)
+
+        mock_print.assert_any_call("Quest creation pipeline complete.")
+# ai-gen end

--- a/tests/test_perl-script-NPCs.py
+++ b/tests/test_perl-script-NPCs.py
@@ -1,0 +1,96 @@
+# ai-gen start (ChatGPT-4, 0)
+import unittest
+from unittest.mock import patch, mock_open, MagicMock
+import sys
+from pathlib import Path
+
+# Importing the module dynamically to allow patching __file__ later
+import importlib.util
+import os
+
+file_path = os.path.abspath("Eulogy-Quest/GPT/perl-script-NPCs.py")
+spec = importlib.util.spec_from_file_location("perl_script_NPCs", file_path)
+perl_script = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(perl_script)
+
+
+class TestPerlScriptNPCs(unittest.TestCase):
+
+    # Tests executing perl-script-NPCs without any additional arguments
+    # When mock-running main, it expects and asserts that the usage message will be printed
+    def test_no_arguments(self):
+        test_args = ["perl-script-NPCs.py"]
+        with patch.object(sys, 'argv', test_args), patch("builtins.print") as mock_print:
+            perl_script.main()      # Simulates running perl-script-NPCs
+            mock_print.assert_any_call("Usage: python3 perl-script-NPCs.py <honored_target>")
+
+    # Tests running perl-script-NPCs while providing only the first name of the honored target
+    # When mock-running main, it expects the error message for not having a string that splits into 2 parts
+    def test_single_word_argument(self):
+        test_args = ["perl-script-NPCs.py", "OnlyFirst"]
+        with patch.object(sys, 'argv', test_args), patch("builtins.print") as mock_print:
+            perl_script.main()
+            mock_print.assert_any_call("Error: honored_target must consist of two words (first and last name)")
+
+    # Tests perl-script-NPCs.py when the honored_target.txt file is not found
+    # Expects an error message
+    def test_missing_honored_target_file(self):
+        test_args = ["perl-script-NPCs.py", "John Doe"]
+        
+        with patch.object(sys, 'argv', test_args), \
+             patch("pathlib.Path.exists", return_value=False), \
+             patch("builtins.print") as mock_print:
+            perl_script.main()
+            
+            # These 2 lines of code allows us to check if the error message is printed
+            # without dealing with the path variable in the formatted string
+            calls = [args[0][0] for args in mock_print.call_args_list]
+            self.assertTrue(any("Error: Could not find honored_target.txt" in call for call in calls))
+
+    # Tests file when ghost_task.txt is not found
+    # Expects an error message
+    def test_missing_ghost_task_file(self):
+        test_args = ["perl-script-NPCs.py", "John Doe"]
+
+        def side_effect(path_obj):
+            # Simulate honored_target.txt exists, ghost_task.txt does not
+            if "honored_target.txt" in str(path_obj):
+                return True
+            if "ghost_task.txt" in str(path_obj):
+                return False
+            return True
+
+        with patch.object(sys, 'argv', test_args), \
+             patch("pathlib.Path.exists", side_effect=side_effect, autospec=True), \
+             patch("pathlib.Path.read_text", return_value="John Doe"), \
+             patch("builtins.print") as mock_print:
+            perl_script.main()
+            calls = [args[0][0] for args in mock_print.call_args_list]
+            self.assertTrue(any("Error: Could not find ghost_task.txt" in call for call in calls))
+
+    # Tests remainder of the file:
+    # Reads text from a mock, valid npc text file and adds npc names to the list variable
+    # Reads text from a mock, quest text file
+    # Mocks making directory
+    # Tests iterating through the npc names list for existing files
+    # Mocks writing the file and copying it
+    @patch("sys.argv", ["perl-script-NPCs.py", "Jane Smith"])
+    @patch("pathlib.Path.mkdir")
+    @patch("pathlib.Path.read_text", side_effect=["Jane Smith", "default quest text", "Custom NPC text"])
+    @patch("pathlib.Path.write_text")
+    @patch("shutil.copy")
+    @patch("pathlib.Path.glob")
+    @patch("builtins.print")
+    def test_script_full_unit_flow(self, mock_print, mock_glob, mock_copy, mock_write, mock_read, mock_mkdir):
+        with patch("pathlib.Path.exists") as mock_exists, patch("pathlib.Path.read_text") as mock_read_text:
+            npc_file_mock = MagicMock()
+            npc_file_mock.read_text.return_value = "NPC One"
+            mock_glob.return_value = [npc_file_mock]
+            perl_script.main()
+
+        # Ensure all major steps were attempted
+        mock_mkdir.assert_called()
+        self.assertTrue(mock_write.called)
+        self.assertTrue(mock_copy.called)
+        self.assertTrue(any("Generated:" in str(call) for call in mock_print.call_args_list))
+# ai-gen end

--- a/tests/test_watch_triggers.py
+++ b/tests/test_watch_triggers.py
@@ -1,0 +1,50 @@
+# ai-gen start (ChatGPT-4, 1)
+import unittest
+from unittest.mock import patch, MagicMock
+import importlib.util
+import os
+import sys
+
+file_path = os.path.abspath("Eulogy-Quest/GPT/watch_triggers.py")
+spec = importlib.util.spec_from_file_location("watch_triggers", file_path)
+watch_triggers = importlib.util.module_from_spec(spec)
+sys.modules["watch_triggers"] = watch_triggers
+spec.loader.exec_module(watch_triggers)
+
+class TestWatchTriggers(unittest.TestCase):
+    def test_extract_name(self):
+        self.assertEqual(
+            watch_triggers.extract_name("path/to/Eulogyquest_John_Doe.trigger"),
+            "John Doe"
+        )
+
+    @patch("watch_triggers.subprocess.run")
+    def test_run_quest_script_success(self, mock_run):
+        mock_run.return_value.returncode = 0
+        mock_run.return_value.stdout = "Success!"
+        result = watch_triggers.run_quest_script("John Doe")
+        self.assertTrue(result)
+
+    @patch("watch_triggers.subprocess.run")
+    def test_run_quest_script_failure(self, mock_run):
+        mock_run.return_value.returncode = 1
+        mock_run.return_value.stderr = "Error occurred"
+        result = watch_triggers.run_quest_script("John Doe")
+        self.assertFalse(result)
+
+    @patch("watch_triggers.os.remove")
+    def test_cleanup_trigger_success(self, mock_remove):
+        watch_triggers.cleanup_trigger("/fake/path.trigger")
+        mock_remove.assert_called_with("/fake/path.trigger")
+
+    @patch("watch_triggers.os.remove", side_effect=OSError("File not found"))
+    def test_cleanup_trigger_failure(self, mock_remove):
+        watch_triggers.cleanup_trigger("/fake/path.trigger")
+        mock_remove.assert_called_with("/fake/path.trigger")
+
+    def test_trigger_handler_enqueue(self):
+        mock_queue = MagicMock()
+        handler = watch_triggers.TriggerHandler(mock_queue)
+        handler.enqueue("/fake/path/Eulogyquest_John_Doe.trigger")
+        mock_queue.put_nowait.assert_called_with("/fake/path/Eulogyquest_John_Doe.trigger")
+# ai-gen end


### PR DESCRIPTION
## [Overview](#overview)
Added new test files for:
- Eulogy-Quest/GPT/create-quest.py
- Eulogy-Quest/GPT/perl-script-NPCs.py
- Eulogy-Quest/GPT/watch_triggers.py*
`* watch_triggers.py contains a couple areas that run indefinitely (one runs until a key press), these were not tested.

Updated yml file to run tests on all python files in Eulogy-Quest/GPT, and installs watchdog for testing watch_triggers.py

Screenshot below shows the results of my tests (also includes other files in Eulogy-Quest/GPT, these files have tests done by Kevin, but his pr has not been merged into master, so I don't have them for this screenshot)
![Screenshot 2025-04-30 230634](https://github.com/user-attachments/assets/1442d147-48f4-4f3b-b891-55e14176d6b1)

## [Diagram](#diagram)
![Diagram](https://raw.githubusercontent.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/master/.github/images/System_Overview.jpeg)

## [YouTrack Ticket](#tickets)
- https://eulogy-quest.youtrack.cloud/issue/EUL-155

## [Github Issue](#issues)
- https://github.com/UNLV-CS472-672/2025-S-GROUP4-EulogyQuest/issues/166
